### PR TITLE
Add macro frame parsing, Demo header fields, and fix entry table layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md — hltv-demo-parser
+
+## Project
+
+PHP 8.2+ library that parses GoldSrc/HLTV `.dem` files (Counter-Strike 1.6 etc.).
+PSR-4: `VitalyArt\DemoParser\` → `src/`.  
+Entrypoint: `VitalyArt\DemoParser\Parser` (`src/Parser.php`).
+
+## Commands
+
+```sh
+./vendor/bin/phpunit                                  # run all tests
+./vendor/bin/phpunit --filter=testMethodName          # single test
+./vendor/bin/phpstan analyse                          # static analysis (level 6)
+make run-php82-tests                                  # Docker-based test on PHP 8.2
+npm run docs:dev                                      # VuePress dev server
+npm run docs:build                                    # build static docs site
+```
+
+## Key facts
+
+- PHPUnit 9.x, config at `test/phpunit/phpunit.xml` (boots `vendor/autoload.php`)
+- PHPStan 2.x level 6, only analyses `src/` (config: `phpstan.neon`)
+- Runtime requirement: `ext-mbstring`
+- All parser exceptions extend `VitalyArt\DemoParser\Exceptions\ParserException` — catch that for any parse error
+- Binary parser: reads fixed-offset fields from `.dem` files; start time extracted from filename pattern `*-YYMMDDHHmm-*`
+- `Demo::getMapCrc()`, `Demo::getGameDirectory()` — header fields at offsets 536 and 276
+- `Entry::getParsedFrames(): DemoFrame[]` — macro block headers (type/time/frame) parsed from LOADING entry data segment. PLAYBACK frame parsing scans end of segment for LAST_IN_SEGMENT frame
+- `Demo::getDuration()` sums `trackTime` across all entries, prefers LAST_IN_SEGMENT frame time
+- `MacroTypeEnum` — 10 macro types (GAME_DATA_START=0, GAME_DATA_NORMAL=1, LAST_IN_SEGMENT=5, etc.)
+- `SIZE_ENTRY = 92` (not 96); entry table starts 4 bytes after directory_offset
+- CI runs `phpunit` then `phpstan analyse` on every push
+- No Composer scripts — use `vendor/bin/` directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v3.1.0
+- `Demo::getDuration()` now derives from the `LAST_IN_SEGMENT` DemoFrame timestamp in the PLAYBACK data segment (falls back to entry `trackTime`)
+- New `Demo::getMapCrc()` — returns the map CRC from the demo header
+- New `Demo::getGameDirectory()` — returns the game directory (e.g. `cstrike`)
+- New `Entry::getParsedFrames(): DemoFrame[]` — parsed macro block headers:
+  - LOADING entries: all sequential macro blocks
+  - PLAYBACK entries: LAST_IN_SEGMENT frame found by scanning the end of the segment
+- New `DemoFrame` class — represents a single macro block (type, time, frame, payload length)
+- New `MacroTypeEnum` — 10 macro types (0–9) used in GoldSrc demo files
+- Fixed entry table parsing: corrected `SIZE_ENTRY` to 92 bytes; entries now start properly after the count field
+
 # v3.0.2
 - Refactor Parser: add constants, fix type safety, improve tests
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ features:
 - title: Reads GoldSrc demos
   details: Supports .dem files from HLTV, Counter-Strike 1.6, Half-Life, Team Fortress Classic, Day of Defeat, and compatible mods.
 - title: Extracts useful metadata
-  details: Returns protocol versions, map name, client name, start and end time, playback duration, and parsed entry details.
+  details: Returns protocol versions, map name, map CRC, game directory, client name, start and end time, playback duration, parsed entries, and macro block frames.
 - title: Small PHP API
   details: Built for PHP 8.2+ with PSR-4 autoloading, readonly DTOs, backed enums, typed exceptions, and only ext-mbstring required.
 - title: Predictable failures

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,4 @@
-## Contributing
-
-### Setup
+## Setup
 
 Clone the repository and install dependencies:
 
@@ -10,7 +8,7 @@ cd hltv-demo-parser
 composer install
 ```
 
-### Running Tests
+## Running Tests
 
 Run PHPUnit tests:
 
@@ -20,7 +18,7 @@ Run PHPUnit tests:
 
 Tests are located in `test/phpunit/unit/`. Make sure all tests pass before submitting changes.
 
-### Static Analysis
+## Static Analysis
 
 Run PHPStan (level 6):
 
@@ -30,7 +28,7 @@ Run PHPStan (level 6):
 
 PHPStan configuration is in `phpstan.neon`.
 
-### Building Documentation
+## Building Documentation
 
 The documentation uses VuePress. To preview locally:
 
@@ -47,7 +45,7 @@ npm run docs:build
 
 The output is placed in `docs/.vuepress/dist/`.
 
-### Pull Request Checklist
+## Pull Request Checklist
 
 - [ ] All tests pass (`./vendor/bin/phpunit --testdox --bootstrap vendor/autoload.php test/phpunit`)
 - [ ] PHPStan reports no errors (`./vendor/bin/phpstan analyse`)

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -2,7 +2,7 @@
 
 The parser throws exceptions when something goes wrong. All exceptions extend `\VitalyArt\DemoParser\Exceptions\ParserException`.
 
-### Exception hierarchy
+## Exception hierarchy
 
 ```
 \Exception
@@ -14,7 +14,7 @@ The parser throws exceptions when something goes wrong. All exceptions extend `\
     └── IsNotADemoException
 ```
 
-### Basic error handling
+## Basic error handling
 
 ```php
 $parser = new \VitalyArt\DemoParser\Parser();
@@ -35,7 +35,7 @@ try {
 }
 ```
 
-### Catching all parser errors
+## Catching all parser errors
 
 If you don't need granular control, catch the base exception:
 
@@ -48,7 +48,7 @@ try {
 }
 ```
 
-### Common pitfalls
+## Common pitfalls
 
 | Scenario | Exception |
 |---|---|

--- a/docs/example.md
+++ b/docs/example.md
@@ -6,10 +6,12 @@ $parser->setDemoFile('/path/to/demo/pub-1609152130-de_dust2_2x2.dem');
 
 $demo = $parser->getDemo();
 
-echo $demo->getDemoProtocol();  // 3
+echo $demo->getDemoProtocol();  // 5
 echo $demo->getNetProtocol();   // 48
 echo $demo->getMapName();       // de_dust2
-echo $demo->getClientName();    // Half-Life
+echo $demo->getClientName();    // cstrike
+echo $demo->getGameDirectory(); // cstrike
+echo $demo->getMapCrc();        // 0
 
 $startTime = $demo->getStartTime(); // DateTimeImmutable or null
 $endTime   = $demo->getEndTime();   // DateTimeImmutable or null
@@ -18,16 +20,24 @@ if ($startTime !== null) {
     echo $startTime->format('Y-m-d H:i:s');
 }
 
-$duration = $demo->getDuration(); // int or false
+$duration = $demo->getDuration(); // int or false (from LAST_IN_SEGMENT frame time)
 
 if ($duration !== false) {
-    echo "Duration: {$duration}s";
+    echo "Duration: {$duration}s"; // e.g. 2891
 }
 
 foreach ($demo->getEntries() as $entry) {
     $type = $entry->getTypeString(); // EntryTypeEnum::LOADING or PLAYBACK
     echo $entry->getDescription();
     echo $entry->getFrames();
+
+    foreach ($entry->getParsedFrames() as $frame) {
+        printf("[%s] time=%.3f frame=%d\n",
+            $frame->getType()->name,
+            $frame->getTime(),
+            $frame->getFrame(),
+        );
+    }
 }
 ```
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,10 +1,8 @@
-## Supported Formats
-
-### Engine
+## Engine
 
 This parser works with demo files from the **GoldSrc engine** — the game engine powering early Valve titles.
 
-### Supported Games
+## Supported Games
 
 | Game | Demo extension |
 |---|---|
@@ -14,20 +12,24 @@ This parser works with demo files from the **GoldSrc engine** — the game engin
 | Day of Defeat | `.dem` |
 | Any GoldSrc-based mod | `.dem` |
 
-### HLTV vs POV Demos
+## HLTV vs POV Demos
 
 The parser supports both types of demo files:
 
 - **HLTV demo** — recorded by an HLTV (Half-Life TV) proxy server. The filename typically contains a timestamp pattern (`-ymdHi-`), which the parser uses to extract `startTime`.
 - **POV (Point of View) demo** — recorded locally by a player using the `record` command. These files usually do not have a timestamp in the filename, so `getStartTime()` returns `null`.
 
-### Demo File Structure
+## Demo File Structure
 
 A `.dem` file consists of:
 
-1. **Header** — 8-byte magic sequence `HLDEMO`, followed by demo protocol version, network protocol version, map name, and client/game directory name.
-2. **Entries** — each entry represents a segment of the demo:
-   - **Loading entry** — contains the map loading data
-   - **Playback entry** — contains the actual recorded gameplay data
+1. **Header** — 8-byte magic sequence `HLDEMO`, followed by demo protocol version (offset 8), network protocol version (offset 12), map name (offset 16), game directory (offset 276), map CRC (offset 536), and directory offset (offset 540).
+2. **Entry table** — array of directory entries, each 92 bytes:
+   - Entry number (4), title string (64), flags (4), CD track (4), track time (4), frame count (4), data offset (4), data length (4)
+3. **Data segments** — each entry points to a segment containing sequential macro blocks:
+   - **Loading segment** — map signon data with server messages, terminated by a `LAST_IN_SEGMENT` marker.
+   - **Playback segment** — recorded gameplay frames with network update messages.
 
-The parser extracts all entries and their metadata (type, description, flags, frames, offset, file length).
+The parser extracts all entries and their metadata (type, description, flags, CD track, track time, frames, offset, file length).  
+For `LOADING` entries, the parser additionally parses the macro block headers (`DemoFrame[]`) from the data segment.  
+`PLAYBACK` frame parsing requires the full HLTV network protocol and is not implemented.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,33 +7,56 @@
 
 ## Class `\VitalyArt\DemoParser\Demo::class`
 
-| Method                    | Return type                     |
-|---------------------------|---------------------------------|
-| $demo->getDemoProtocol(); | int                             |
-| $demo->getNetProtocol();  | int                             |
-| $demo->getMapName();      | string                          |
-| $demo->getClientName();   | string                          |
-| $demo->getStartTime();    | DateTimeImmutable\|null         |
-| $demo->getEndTime();      | DateTimeImmutable\|null         |
-| $demo->getDuration();     | int\|false                      |
+| Method                     | Return type                     |
+|----------------------------|---------------------------------|
+| $demo->getDemoProtocol();  | int                             |
+| $demo->getNetProtocol();   | int                             |
+| $demo->getMapName();       | string                          |
+| $demo->getClientName();    | string                          |
+| $demo->getMapCrc();        | int                             |
+| $demo->getGameDirectory(); | string                          |
+| $demo->getStartTime();     | DateTimeImmutable\|null         |
+| $demo->getEndTime();       | DateTimeImmutable\|null         |
+| $demo->getDuration();      | int\|false                      |
+| $demo->getEntries();       | \VitalyArt\DemoParser\Entry[]   |
 
 > `getStartTime()` returns `null` when the demo filename does not contain a date pattern (`-ymdHi-`).  
 > `getEndTime()` returns `null` when `getStartTime()` is `null`.  
-> `getDuration()` returns `false` when no playback entry is found in the demo.
+> `getDuration()` returns `false` when no entry with track time is found.  
+> The method sums `getTrackTime()` from all entries, preferring `LAST_IN_SEGMENT` DemoFrame timestamps where available (parsed from entry data segments).  
+> `getMapCrc()` returns the CRC-32 of the map file stored in the demo header (often 0 in HLTV demos).  
+> `getGameDirectory()` returns the game directory (e.g. `cstrike`, `valve`, `gearbox`).
 
 ## Class `\VitalyArt\DemoParser\Entry::class`
 
-| Method                   | Return type                                     |
-|--------------------------|-------------------------------------------------|
-| $entry->getTypeString()  | \VitalyArt\DemoParser\Enums\EntryTypeEnum       |
-| $entry->getType()        | int                                             |
-| $entry->getDescription() | string                                          |
-| $entry->getFlags()       | int                                             |
-| $entry->getCDTrack()     | int                                             |
-| $entry->getTrackTime()   | float                                           |
-| $entry->getFrames()      | int                                             |
-| $entry->getOffset()      | int                                             |
-| $entry->getFileLength()  | int                                             |
+| Method                     | Return type                                     |
+|----------------------------|-------------------------------------------------|
+| $entry->getTypeString()    | \VitalyArt\DemoParser\Enums\EntryTypeEnum       |
+| $entry->getType()          | int                                             |
+| $entry->getDescription()   | string                                          |
+| $entry->getFlags()         | int                                             |
+| $entry->getCDTrack()       | int                                             |
+| $entry->getTrackTime()     | float                                           |
+| $entry->getFrames()        | int                                             |
+| $entry->getOffset()        | int                                             |
+| $entry->getFileLength()    | int                                             |
+| $entry->getParsedFrames()  | \VitalyArt\DemoParser\DemoFrame[]               |
+
+> `getParsedFrames()` returns an array of parsed macro blocks from the entry's data segment.  
+> For `LOADING` entries, all macro blocks are parsed sequentially.  
+> For `PLAYBACK` entries, the method scans the end of the data segment for the  
+> `LAST_IN_SEGMENT` frame (which contains the final playback timestamp).
+
+## Class `\VitalyArt\DemoParser\DemoFrame::class`
+
+Each demo frame represents a sequential macro block extracted from an entry's data segment.
+
+| Method                     | Return type                            |
+|----------------------------|----------------------------------------|
+| $frame->getType()          | \VitalyArt\DemoParser\Enums\MacroTypeEnum |
+| $frame->getTime()          | float                                  |
+| $frame->getFrame()         | int                                    |
+| $frame->getPayloadLength() | int                                    |
 
 ## Enum `\VitalyArt\DemoParser\Enums\EntryTypeEnum`
 
@@ -43,6 +66,23 @@ A backed string enum representing the type of demo entry.
 |-------------|------------|--------------------------------------------------|
 | LOADING     | `'loading'`  | Loading segment — map is being loaded             |
 | PLAYBACK    | `'playback'` | Playback segment — the actual recorded gameplay   |
+
+## Enum `\VitalyArt\DemoParser\Enums\MacroTypeEnum`
+
+A backed integer enum representing the macro block type within an entry's data segment.
+
+| Case             | Value | Description                                     |
+|------------------|-------|-------------------------------------------------|
+| GAME_DATA_START  | 0     | Game data with initial signon messages           |
+| GAME_DATA_NORMAL | 1     | Game data with normal update messages            |
+| UNUSED           | 2     | Tick marker (no payload)                         |
+| CLIENT_COMMAND   | 3     | Client console command string                    |
+| STRING           | 4     | Generic string data                              |
+| LAST_IN_SEGMENT  | 5     | End of the current data segment                  |
+| UNKNOWN_6        | 6     | Reserved                                         |
+| UNKNOWN_7        | 7     | Reserved                                         |
+| PLAY_SOUND       | 8     | Play a sound effect                              |
+| DELTA_DATA       | 9     | Delta-compressed data                            |
 
 ## Exceptions
 

--- a/src/Demo.php
+++ b/src/Demo.php
@@ -8,19 +8,20 @@ use DateTimeImmutable;
 
 readonly class Demo
 {
+    /** @param Entry[] $entries */
     public function __construct(
         private int $demoProtocol,
         private int $netProtocol,
         private string $mapName,
         private string $clientName,
-        /** @var Entry[] */
         private array $entries,
         private DateTimeImmutable|null $startTime,
         private DateTimeImmutable|null $endTime,
         private int|false $duration,
+        private int $mapCrc = 0,
+        private string $gameDirectory = '',
     )
     {
-
     }
 
     public function getDemoProtocol(): int
@@ -43,9 +44,7 @@ readonly class Demo
         return $this->clientName;
     }
 
-    /**
-     * @return Entry[]
-     */
+    /** @return Entry[] */
     public function getEntries(): array
     {
         return $this->entries;
@@ -64,5 +63,15 @@ readonly class Demo
     public function getDuration(): int|false
     {
         return $this->duration;
+    }
+
+    public function getMapCrc(): int
+    {
+        return $this->mapCrc;
+    }
+
+    public function getGameDirectory(): string
+    {
+        return $this->gameDirectory;
     }
 }

--- a/src/DemoFrame.php
+++ b/src/DemoFrame.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VitalyArt\DemoParser;
+
+use VitalyArt\DemoParser\Enums\MacroTypeEnum;
+
+readonly class DemoFrame
+{
+    public function __construct(
+        private MacroTypeEnum $type,
+        private float $time,
+        private int $frame,
+        private int $payloadLength,
+    )
+    {
+    }
+
+    public function getType(): MacroTypeEnum
+    {
+        return $this->type;
+    }
+
+    public function getTime(): float
+    {
+        return $this->time;
+    }
+
+    public function getFrame(): int
+    {
+        return $this->frame;
+    }
+
+    public function getPayloadLength(): int
+    {
+        return $this->payloadLength;
+    }
+}

--- a/src/Entry.php
+++ b/src/Entry.php
@@ -8,6 +8,7 @@ use VitalyArt\DemoParser\Enums\EntryTypeEnum;
 
 readonly class Entry
 {
+    /** @param DemoFrame[] $parsedFrames */
     public function __construct(
         private EntryTypeEnum $type,
         private int $typeNumber,
@@ -18,80 +19,59 @@ readonly class Entry
         private int $frames,
         private int $offset,
         private int $fileLength,
+        private array $parsedFrames = [],
     )
     {
-
     }
 
-    /**
-     * Entry type
-     */
     public function getTypeString(): EntryTypeEnum
     {
         return $this->type;
     }
 
-    /**
-     * Integer entry type
-     */
     public function getType(): int
     {
         return $this->typeNumber;
     }
 
-    /**
-     * Description
-     */
     public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * Flags
-     */
     public function getFlags(): int
     {
         return $this->flags;
     }
 
-    /**
-     * CD track
-     */
     public function getCDTrack(): int
     {
         return $this->CDTrack;
     }
 
-    /**
-     * Track time
-     */
     public function getTrackTime(): float
     {
         return $this->trackTime;
     }
 
-    /**
-     * Frames
-     */
     public function getFrames(): int
     {
         return $this->frames;
     }
 
-    /**
-     * Offset
-     */
     public function getOffset(): int
     {
         return $this->offset;
     }
 
-    /**
-     * File length
-     */
     public function getFileLength(): int
     {
         return $this->fileLength;
+    }
+
+    /** @return DemoFrame[] */
+    public function getParsedFrames(): array
+    {
+        return $this->parsedFrames;
     }
 }

--- a/src/Enums/MacroTypeEnum.php
+++ b/src/Enums/MacroTypeEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace VitalyArt\DemoParser\Enums;
+
+enum MacroTypeEnum: int
+{
+    case GAME_DATA_START  = 0;
+    case GAME_DATA_NORMAL = 1;
+    case UNUSED           = 2;
+    case CLIENT_COMMAND   = 3;
+    case STRING           = 4;
+    case LAST_IN_SEGMENT  = 5;
+    case UNKNOWN_6        = 6;
+    case UNKNOWN_7        = 7;
+    case PLAY_SOUND       = 8;
+    case DELTA_DATA       = 9;
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -6,6 +6,7 @@ namespace VitalyArt\DemoParser;
 
 use DateTimeImmutable;
 use VitalyArt\DemoParser\Enums\EntryTypeEnum;
+use VitalyArt\DemoParser\Enums\MacroTypeEnum;
 use VitalyArt\DemoParser\Exceptions\FileNotExistsException;
 use VitalyArt\DemoParser\Exceptions\FileNotSpecifiedException;
 use VitalyArt\DemoParser\Exceptions\IsNotADemoException;
@@ -18,12 +19,24 @@ class Parser
     private const OFFSET_NET_PROTOCOL = 12;
     private const OFFSET_MAP_NAME = 16;
     private const OFFSET_CLIENT_NAME = 276;
+    private const OFFSET_MAP_CRC = 536;
     private const OFFSET_ENTRIES_TABLE = 540;
     private const SIZE_PROTOCOL_STRING = 260;
     private const SIZE_ENTRY_STRING = 64;
     private const SIZE_INT = 4;
     private const SIZE_FLOAT = 4;
-    private const SIZE_ENTRY = 96;
+    private const SIZE_ENTRY = 92;
+    private const MACRO_HEADER_SIZE = 9;
+    private const EXTINFO_SIZE_NET42 = 560;
+    private const EXTINFO_SIZE_NET45 = 464;
+    private const MACRO6_PAYLOAD_SIZE = 84;
+    private const MACRO7_PAYLOAD_SIZE = 8;
+    private const SOUND_PREFIX_SIZE = 8;
+    private const SOUND_SUFFIX_SIZE = 16;
+    private const MAX_STRING_SCAN = 4096;
+    private const LAST_FRAME_SCAN_RANGE = 512;
+    private const MAX_VALID_TIME = 100000;
+    private const MAX_VALID_FRAME = 1000000;
     private const OFFSET_ENTRY_TYPE = 4;
     private const OFFSET_ENTRY_FLAGS = 68;
     private const OFFSET_ENTRY_CDTRACK = 72;
@@ -32,34 +45,19 @@ class Parser
     private const OFFSET_ENTRY_OFFSET = 84;
     private const OFFSET_ENTRY_FILELENGTH = 88;
 
-    /**
-     * Demo object
-     */
     private Demo $demo;
-
-    /**
-     * Name of demo file without extension
-     */
     private string $fileName;
+    private int $demoProtocol = 0;
+    private int $netProtocol = 0;
 
-    /**
-     * @var resource
-     */
+    /** @var resource */
     private $handle;
 
-    /**
-     * @var Entry[]|null
-     */
+    /** @var Entry[]|null */
     private array|null $entries = null;
 
-    /**
-     * @var string Path to demo file
-     */
     private string $demoFile = '';
 
-    /**
-     * Process
-     */
     private function bootstrap(): void
     {
         $this->fileName = pathinfo($this->demoFile, PATHINFO_FILENAME);
@@ -69,45 +67,38 @@ class Parser
         fclose($this->handle);
     }
 
-    /**
-     * Set demo file
-     * @param string $demoFile Path to demo file
-     */
     public function setDemoFile(string $demoFile): void
     {
         $this->demoFile = $demoFile;
     }
 
-    /**
-     * Fill demo from data
-     */
     private function fillDemo(): void
     {
-        $demoProtocol = $this->readInt(self::OFFSET_DEMO_PROTOCOL);
-        $netProtocol = $this->readInt(self::OFFSET_NET_PROTOCOL);
-        $mapName = $this->readData(self::OFFSET_MAP_NAME, self::SIZE_PROTOCOL_STRING);
-        $clientName = $this->readData(self::OFFSET_CLIENT_NAME, self::SIZE_PROTOCOL_STRING);
+        $this->demoProtocol = $this->readInt(self::OFFSET_DEMO_PROTOCOL) ?: 0;
+        $this->netProtocol = $this->readInt(self::OFFSET_NET_PROTOCOL) ?: 0;
+        $mapName = $this->readData(self::OFFSET_MAP_NAME, self::SIZE_PROTOCOL_STRING) ?: '';
+        $clientName = $this->readData(self::OFFSET_CLIENT_NAME, self::SIZE_PROTOCOL_STRING) ?: '';
+        $mapCrc = $this->readInt(self::OFFSET_MAP_CRC) ?: 0;
+        $gameDirectory = $this->readData(self::OFFSET_CLIENT_NAME, self::SIZE_PROTOCOL_STRING) ?: '';
         $entries = $this->getEntries();
         $startDate = $this->getStartDate();
         $duration = $this->getDuration();
         $endTime = $this->computeEndTime($startDate, $duration);
 
         $this->demo = new Demo(
-            $demoProtocol ?: 0,
-            $netProtocol ?: 0,
-            $mapName ?: '',
-            $clientName ?: '',
+            $this->demoProtocol,
+            $this->netProtocol,
+            $mapName,
+            $clientName,
             $entries,
             $startDate,
             $endTime,
             $duration,
+            $mapCrc,
+            $gameDirectory,
         );
     }
 
-    /**
-     * @return Demo
-     * @throws FileNotSpecifiedException
-     */
     public function getDemo(): Demo
     {
         if (!$this->demoFile) {
@@ -118,11 +109,6 @@ class Parser
         return $this->demo;
     }
 
-    /**
-     * Checks a file
-     * @throws FileNotExistsException If file not found on file system
-     * @throws WrongExtensionException If file extension is not a DEM
-     */
     private function checkFile(): void
     {
         if (!is_file($this->demoFile)) {
@@ -134,10 +120,6 @@ class Parser
         }
     }
 
-    /**
-     * @throws NotReadableException If file is not readable
-     * @throws IsNotADemoException IF file is a not demo
-     */
     private function handle(): void
     {
         $this->handle = fopen($this->demoFile, 'r');
@@ -151,9 +133,7 @@ class Parser
         }
     }
 
-    /**
-     * @return Entry[]
-     */
+    /** @return Entry[] */
     private function getEntries(): array
     {
         $entriesOffset = $this->readInt(self::OFFSET_ENTRIES_TABLE);
@@ -164,14 +144,14 @@ class Parser
 
         $entriesCount = $this->readInt($entriesOffset);
 
-        if ($entriesCount === false) {
+        if ($entriesCount === false || $entriesCount <= 0 || $entriesCount > 1024) {
             return [];
         }
 
         $this->entries = [];
 
         for ($i = 0; $i < $entriesCount; $i++) {
-            $baseOffset = $entriesOffset + self::SIZE_ENTRY * $i;
+            $baseOffset = $entriesOffset + self::SIZE_INT + self::SIZE_ENTRY * $i;
             $typeStringRaw = $this->readData($baseOffset + self::OFFSET_ENTRY_TYPE, self::SIZE_ENTRY_STRING);
 
             if (!$typeStringRaw) {
@@ -201,6 +181,8 @@ class Parser
                 continue;
             }
 
+            $parsedFrames = $this->parseEntryFrames($offset, $fileLength, $entryType);
+
             $entry = new Entry(
                 $entryType,
                 $type,
@@ -211,6 +193,7 @@ class Parser
                 $frames,
                 $offset,
                 $fileLength,
+                $parsedFrames,
             );
 
             if ($this->isValidEntry($entry)) {
@@ -221,9 +204,230 @@ class Parser
         return $this->entries;
     }
 
-    /**
-     * Start time
-     */
+    /** @return DemoFrame[] */
+    private function parseEntryFrames(int $entryOffset, int $entryLength, EntryTypeEnum $entryType): array
+    {
+        if ($entryLength <= 0) {
+            return [];
+        }
+
+        if ($entryType === EntryTypeEnum::PLAYBACK) {
+            return $this->findLastFrameInSegment($entryOffset, $entryLength);
+        }
+
+        $frames = [];
+        $pos = $entryOffset;
+        $end = $entryOffset + $entryLength;
+
+        while ($pos + 9 <= $end) {
+            if (fseek($this->handle, $pos) === -1) {
+                break;
+            }
+
+            $typeByte = fread($this->handle, 1);
+            if ($typeByte === false || $typeByte === '') {
+                break;
+            }
+            $type = unpack('C', $typeByte)[1];
+
+            $timeData = fread($this->handle, self::SIZE_FLOAT);
+            if ($timeData === false || strlen($timeData) < self::SIZE_FLOAT) {
+                break;
+            }
+            $time = unpack('f', $timeData)[1];
+
+            $frameData = fread($this->handle, self::SIZE_INT);
+            if ($frameData === false || strlen($frameData) < self::SIZE_INT) {
+                break;
+            }
+            $frame = unpack('i', $frameData)[1];
+
+            $payloadLength = $this->skipMacroPayload($type, $pos + 9, $end);
+
+            $macroType = MacroTypeEnum::tryFrom($type);
+            $frames[] = new DemoFrame(
+                $macroType ?? MacroTypeEnum::UNUSED,
+                $time,
+                $frame,
+                $payloadLength,
+            );
+
+            if ($type === 5) {
+                break;
+            }
+
+            $pos += 9 + $payloadLength;
+        }
+
+        return $frames;
+    }
+
+    /** @return DemoFrame[] */
+    private function findLastFrameInSegment(int $entryOffset, int $entryLength): array
+    {
+        $end = $entryOffset + $entryLength - self::MACRO_HEADER_SIZE;
+        $scanStart = $entryOffset + max(0, $entryLength - self::LAST_FRAME_SCAN_RANGE);
+
+        for ($pos = $end; $pos >= $scanStart; $pos--) {
+            if (fseek($this->handle, $pos) === -1) {
+                break;
+            }
+
+            $typeByte = fread($this->handle, 1);
+            if ($typeByte === false || $typeByte === '') {
+                break;
+            }
+            $type = unpack('C', $typeByte)[1];
+
+            if ($type !== MacroTypeEnum::LAST_IN_SEGMENT->value) {
+                continue;
+            }
+
+            $timeData = fread($this->handle, self::SIZE_FLOAT);
+            if ($timeData === false || strlen($timeData) < self::SIZE_FLOAT) {
+                continue;
+            }
+            $time = unpack('f', $timeData)[1];
+
+            $frameData = fread($this->handle, self::SIZE_INT);
+            if ($frameData === false || strlen($frameData) < self::SIZE_INT) {
+                continue;
+            }
+            $frame = unpack('i', $frameData)[1];
+
+            if ($time < 0 || $time > self::MAX_VALID_TIME || $frame < 0 || $frame > self::MAX_VALID_FRAME) {
+                continue;
+            }
+
+            return [new DemoFrame(MacroTypeEnum::LAST_IN_SEGMENT, $time, $frame, 0)];
+        }
+
+        return [];
+    }
+
+    private function skipMacroPayload(int $type, int $payloadPos, int $end): int
+    {
+        switch ($type) {
+            case MacroTypeEnum::GAME_DATA_START->value:
+            case MacroTypeEnum::GAME_DATA_NORMAL->value:
+                $extinfoSize = ($this->netProtocol === 42)
+                    ? self::EXTINFO_SIZE_NET42
+                    : self::EXTINFO_SIZE_NET45;
+                $dataPos = $payloadPos + $extinfoSize;
+
+                if ($dataPos + self::SIZE_INT > $end) {
+                    return 0;
+                }
+
+                if (fseek($this->handle, $dataPos) === -1) {
+                    return 0;
+                }
+
+                $chunkLenData = fread($this->handle, self::SIZE_INT);
+                if ($chunkLenData === false || strlen($chunkLenData) < self::SIZE_INT) {
+                    return 0;
+                }
+
+                $chunkLength = unpack('i', $chunkLenData)[1];
+                if ($chunkLength < 0) {
+                    return 0;
+                }
+
+                return $extinfoSize + self::SIZE_INT + $chunkLength;
+
+            case MacroTypeEnum::UNUSED->value:
+                return 0;
+
+            case MacroTypeEnum::CLIENT_COMMAND->value:
+            case MacroTypeEnum::STRING->value:
+                return $this->readStringLength($payloadPos, $end);
+
+            case MacroTypeEnum::LAST_IN_SEGMENT->value:
+                return 0;
+
+            case MacroTypeEnum::UNKNOWN_6->value:
+                return self::MACRO6_PAYLOAD_SIZE;
+
+            case MacroTypeEnum::UNKNOWN_7->value:
+                return self::MACRO7_PAYLOAD_SIZE;
+
+            case MacroTypeEnum::PLAY_SOUND->value:
+                return $this->readSoundPayloadLength($payloadPos, $end);
+
+            case MacroTypeEnum::DELTA_DATA->value:
+                return $this->readDeltaPayloadLength($payloadPos, $end);
+
+            default:
+                return 0;
+        }
+    }
+
+    private function readStringLength(int $pos, int $end): int
+    {
+        if (fseek($this->handle, $pos) === -1) {
+            return 0;
+        }
+
+        $max = min($end - $pos, self::MAX_STRING_SCAN);
+        $data = fread($this->handle, $max);
+        if ($data === false) {
+            return 0;
+        }
+
+        $nullPos = strpos($data, "\0");
+        if ($nullPos === false) {
+            return strlen($data);
+        }
+
+        return $nullPos + 1;
+    }
+
+    private function readSoundPayloadLength(int $pos, int $end): int
+    {
+        if ($pos + self::SOUND_PREFIX_SIZE > $end) {
+            return 0;
+        }
+
+        if (fseek($this->handle, $pos + self::SIZE_INT) === -1) {
+            return 0;
+        }
+
+        $nameLenData = fread($this->handle, self::SIZE_INT);
+        if ($nameLenData === false || strlen($nameLenData) < self::SIZE_INT) {
+            return 0;
+        }
+
+        $nameLength = unpack('i', $nameLenData)[1];
+        if ($nameLength < 0 || $nameLength > 256) {
+            return 0;
+        }
+
+        return self::SOUND_PREFIX_SIZE + $nameLength + self::SOUND_SUFFIX_SIZE;
+    }
+
+    private function readDeltaPayloadLength(int $pos, int $end): int
+    {
+        if ($pos + 4 > $end) {
+            return 0;
+        }
+
+        if (fseek($this->handle, $pos) === -1) {
+            return 0;
+        }
+
+        $lenData = fread($this->handle, self::SIZE_INT);
+        if ($lenData === false || strlen($lenData) < self::SIZE_INT) {
+            return 0;
+        }
+
+        $chunkLength = unpack('i', $lenData)[1];
+        if ($chunkLength < 0) {
+            return 0;
+        }
+
+        return self::SIZE_INT + $chunkLength;
+    }
+
     private function getStartDate(): DateTimeImmutable|null
     {
         if (preg_match('/.+-(\d+)-.+/', $this->fileName, $matches)) {
@@ -244,13 +448,31 @@ class Parser
 
     private function getDuration(): int|false
     {
+        $total = 0.0;
+        $found = false;
+
         foreach ($this->getEntries() as $entry) {
-            if ($entry->getTypeString() === EntryTypeEnum::PLAYBACK) {
-                return intval($entry->getTrackTime());
+            $entryTime = 0.0;
+            $fromFrame = false;
+
+            foreach ($entry->getParsedFrames() as $frame) {
+                if ($frame->getType() === MacroTypeEnum::LAST_IN_SEGMENT) {
+                    $entryTime = $frame->getTime();
+                    $fromFrame = true;
+                }
+            }
+
+            if (!$fromFrame) {
+                $entryTime = $entry->getTrackTime();
+            }
+
+            if ($entryTime > 0) {
+                $total += $entryTime;
+                $found = true;
             }
         }
 
-        return false;
+        return $found ? intval($total) : false;
     }
 
     private function isValidEntry(Entry $entry): bool

--- a/test/phpunit/unit/HltvDemoParserTest.php
+++ b/test/phpunit/unit/HltvDemoParserTest.php
@@ -7,7 +7,9 @@ namespace phpunit\unit;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use VitalyArt\DemoParser\Demo;
+use VitalyArt\DemoParser\DemoFrame;
 use VitalyArt\DemoParser\Enums\EntryTypeEnum;
+use VitalyArt\DemoParser\Enums\MacroTypeEnum;
 use VitalyArt\DemoParser\Entry;
 use VitalyArt\DemoParser\Exceptions\FileNotExistsException;
 use VitalyArt\DemoParser\Exceptions\FileNotSpecifiedException;
@@ -92,6 +94,7 @@ class HltvDemoParserTest extends TestCase
         $duration = $demo->getDuration();
         $this->assertIsInt($duration);
         $this->assertGreaterThan(0, $duration);
+        $this->assertEquals(2891, $duration);
     }
 
     public function testGetMapName(): void
@@ -169,6 +172,49 @@ class HltvDemoParserTest extends TestCase
         $this->assertInstanceOf(Demo::class, $demo);
         $this->assertIsArray($demo->getEntries());
         $this->assertCount(0, $demo->getEntries());
+    }
+
+    public function testGetMapCrc(): void
+    {
+        $this->setValidDemo();
+        $demo = $this->parser->getDemo();
+        $this->assertIsInt($demo->getMapCrc());
+    }
+
+    public function testGetGameDirectory(): void
+    {
+        $this->setValidDemo();
+        $demo = $this->parser->getDemo();
+        $this->assertIsString($demo->getGameDirectory());
+        $this->assertNotEmpty($demo->getGameDirectory());
+    }
+
+    public function testLoadingEntryParsedFrames(): void
+    {
+        $this->setValidDemo();
+        $demo = $this->parser->getDemo();
+        $entry = $demo->getEntries()['loading'];
+        $frames = $entry->getParsedFrames();
+        $this->assertIsArray($frames);
+        $this->assertGreaterThan(0, count($frames));
+    }
+
+    public function testLoadingParsedFramesStructure(): void
+    {
+        $this->setValidDemo();
+        $demo = $this->parser->getDemo();
+        $frames = $demo->getEntries()['loading']->getParsedFrames();
+
+        $this->assertContainsOnlyInstancesOf(DemoFrame::class, $frames);
+
+        $first = $frames[0];
+        $this->assertInstanceOf(MacroTypeEnum::class, $first->getType());
+        $this->assertIsFloat($first->getTime());
+        $this->assertIsInt($first->getFrame());
+        $this->assertIsInt($first->getPayloadLength());
+
+        $last = $frames[count($frames) - 1];
+        $this->assertSame(MacroTypeEnum::LAST_IN_SEGMENT, $last->getType());
     }
 
     protected function setValidDemo(): void


### PR DESCRIPTION
## Summary

### New classes
- `DemoFrame` — readonly DTO with `getType()`, `getTime()`, `getFrame()`, `getPayloadLength()`
- `MacroTypeEnum` — backed int enum for 10 GoldSrc macro types (0–9)

### New methods
- `Demo::getMapCrc(): int` — map CRC from header offset 536
- `Demo::getGameDirectory(): string` — game directory from offset 276 (e.g. `cstrike`)
- `Entry::getParsedFrames(): DemoFrame[]` — macro block headers:
  - LOADING: all sequential macro blocks parsed from data segment
  - PLAYBACK: LAST_IN_SEGMENT frame found by scanning end of segment
- `DemoFrame::getType()`, `getTime()`, `getFrame()`, `getPayloadLength()`

### Changes
- `Demo::getDuration()` now sums `trackTime` across all entries, prefers LAST_IN_SEGMENT frame timestamps
- Entry table parsing fixed: `SIZE_ENTRY` corrected from 96 to 92 bytes; entries now start after the count field (`dir_offset + 4`)

### Documentation
- Updated VuePress reference, example, formats, changelog, and landing page
- Created `AGENTS.md` for future OpenCode sessions

### Tests
- 4 new tests: `testGetMapCrc`, `testGetGameDirectory`, `testLoadingEntryParsedFrames`, `testLoadingParsedFramesStructure`
- Extended `testGetDuration` with expected value assertion (2891s)